### PR TITLE
feat: add 3D advanced map

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
 <body>
 <!-- partial:index.partial.html -->
 <canvas id="canvas"></canvas>
+<div id="scene3d"></div>
 
 <p>
   Use the left, right and up arrow keys to move.
@@ -17,7 +18,9 @@
 <br>
 <a target="_blank" href="https://github.com/Prajeesh-A">Click Me</a>
 <!-- partial -->
-  <script  src="./script.js"></script>
+  <script src="https://unpkg.com/three@0.150.1/build/three.min.js"></script>
+  <script src="https://unpkg.com/three@0.150.1/examples/js/controls/OrbitControls.js"></script>
+  <script src="./script.js"></script>
 
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -144,6 +144,35 @@ var map = {
     }
 };
 
+var advancedMap = {
+    tile_size: 16,
+    keys: [
+        {id: 0, colour: '#333', solid: 0},
+        {id: 1, colour: '#888', solid: 0},
+        {id: 2, colour: '#555', solid: 1, bounce: 0.35},
+        {id: 3, colour: '#0FF', solid: 0, script: 'teleport'},
+        {id: 4, colour: '#C93232', solid: 0, script: 'death'},
+        {id: 5, colour: '#FADF73', solid: 0, script: 'win'}
+    ],
+    data: [
+        [2,2,2,2,2,2,2,2,2,2],
+        [2,1,1,1,1,1,1,1,3,2],
+        [2,1,2,1,1,1,4,1,1,2],
+        [2,1,2,1,2,2,2,1,1,2],
+        [2,1,1,1,1,5,1,1,1,2],
+        [2,2,2,2,2,2,2,2,2,2]
+    ],
+    gravity: {x:0, y:0.3},
+    vel_limit: {x:2, y:16},
+    movement_speed: {jump:6, left:0.3, right:0.3},
+    player: {x:1, y:1, colour:'#33cc33'},
+    scripts: {
+        teleport: 'game.player.loc.x = 7; game.player.loc.y = 1;',
+        win: 'alert("You reached the goal!");',
+        death: 'alert("You died!");game.load_map(advancedMap);'
+    }
+};
+
 /* Clarity engine */
 
 var Clarity = function () {
@@ -591,6 +620,43 @@ Clarity.prototype.draw = function (context) {
     this.draw_player(context);
 };
 
+function render3DMap(mapData) {
+    if (typeof THREE === 'undefined') return;
+    var container = document.getElementById('scene3d');
+    if (!container) return;
+    var width = container.clientWidth;
+    var height = container.clientHeight;
+    var scene = new THREE.Scene();
+    var camera = new THREE.PerspectiveCamera(45, width / height, 0.1, 1000);
+    var renderer = new THREE.WebGLRenderer();
+    renderer.setSize(width, height);
+    container.appendChild(renderer.domElement);
+
+    var tileSize = mapData.tile_size;
+    for (var y = 0; y < mapData.data.length; y++) {
+        for (var x = 0; x < mapData.data[y].length; x++) {
+            var id = mapData.data[y][x];
+            var key = mapData.keys.find(function(k){ return k.id === id; }) || {colour: '#ccc'};
+            var geometry = new THREE.BoxGeometry(tileSize, tileSize / 2, tileSize);
+            var material = new THREE.MeshBasicMaterial({color: key.colour});
+            var cube = new THREE.Mesh(geometry, material);
+            cube.position.set(x * tileSize, -tileSize / 4, y * tileSize);
+            scene.add(cube);
+        }
+    }
+
+    camera.position.set(tileSize * mapData.data[0].length / 2, 200, tileSize * mapData.data.length);
+    if (THREE.OrbitControls) {
+        new THREE.OrbitControls(camera, renderer.domElement);
+    }
+
+    function animate() {
+        requestAnimationFrame(animate);
+        renderer.render(scene, camera);
+    }
+    animate();
+}
+
 /* Setup of the engine */
 
 window.requestAnimFrame =
@@ -611,7 +677,8 @@ canvas.height = 400;
 
 var game = new Clarity();
     game.set_viewport(canvas.width, canvas.height);
-    game.load_map(map);
+    game.load_map(advancedMap);
+    render3DMap(advancedMap);
 
     /* Limit the viewport to the confines of the map */
     game.limit_viewport = true;

--- a/style.css
+++ b/style.css
@@ -14,6 +14,12 @@ canvas {
   box-shadow: 0 0 16px 2px rgba(0,0,0,0.8);
 }
 
+#scene3d {
+  width: 600px;
+  height: 400px;
+  margin: 20px auto;
+}
+
 p, a {
   font-family: Helvetica, Arial, sans-serif;
   font-size: 19px;


### PR DESCRIPTION
## Summary
- add Three.js and orbit controls for 3D rendering
- implement advanced map with teleport, hazards and goal tiles
- render map as 3D scene alongside existing canvas

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aaa223fc0c832a9f21b448f67da6a7